### PR TITLE
v0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ jobs:
       - checkout
       - run:
           name: Install Deno
-          command: curl -fsSL https://deno.land/x/install/install.sh | sh -s -- v0.17.0
+          command: curl -fsSL https://deno.land/x/install/install.sh | sh -s -- v0.19.0
       - run:
           name: Run Tests
           command: |
             export PATH=$HOME/.deno/bin:$PATH
-            deno -A test.ts
+            deno -A test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 deno.d.ts
 .idea
 commands
-tsconfig.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,2 @@
 redis:
 	docker run -p 6379:6379 -d -t redis:5
-test:
-	deno --allow-net test.ts

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![CircleCI](https://circleci.com/gh/keroxp/deno-redis.svg?style=svg)](https://circleci.com/gh/keroxp/deno-redis)
 ![https://img.shields.io/github/tag/keroxp/deno-redis.svg](https://img.shields.io/github/tag/keroxp/deno-redis.svg)
 [![license](https://img.shields.io/github/license/keroxp/deno-redis.svg)](https://github.com/keroxp/deno-redis)
-[![tag](https://img.shields.io/badge/deno__std-v0.17.0-green.svg)](https://github.com/denoland/deno_std)
-[![tag](https://img.shields.io/badge/deno-v0.17.0-green.svg)](https://github.com/denoland/deno)
+[![tag](https://img.shields.io/badge/deno__std-v0.18.0-green.svg)](https://github.com/denoland/deno_std)
+[![tag](https://img.shields.io/badge/deno-v0.19.0-green.svg)](https://github.com/denoland/deno)
 
 An experimental implementation of redis client for deno
 
@@ -16,7 +16,7 @@ needs `--allow-net` privilege
 
 ```ts
 import { connect } from "https://denopkg.com/keroxp/deno-redis/redis.ts";
-const redis = await connect("127.0.0.1:6379");
+const redis = await connect("http://127.0.0.1:6379");
 const ok = await redis.set("hoge", "fuga");
 const fuga = await redis.get("hoge");
 ```
@@ -39,7 +39,10 @@ const sub = await redis.subscribe("channel");
 https://redis.io/topics/pipelining
 
 ```ts
-const redis = await connect("127.0.0.1:6379");
+const redis = await connect({
+  hostname: "127.0.0.1",
+  port: 6379
+});
 const pl = redis.pipeline();
 await Promise.all([
   pl.ping(),

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ needs `--allow-net` privilege
 
 ```ts
 import { connect } from "https://denopkg.com/keroxp/deno-redis/redis.ts";
-const redis = await connect("http://127.0.0.1:6379");
+const redis = await connect({
+  hostname: "127.0.0.1",
+  port: 6379
+});
 const ok = await redis.set("hoge", "fuga");
 const fuga = await redis.get("hoge");
 ```

--- a/modules-lock.json
+++ b/modules-lock.json
@@ -1,1 +1,11 @@
-{"https://deno.land/std":{"version":"@v0.18.0","modules":["/testing/mod.ts","/testing/asserts.ts","/io/bufio.ts","/fmt/colors.ts"]}}
+{
+  "https://deno.land/std": {
+    "version": "@v0.18.0",
+    "modules": [
+      "/testing/mod.ts",
+      "/testing/asserts.ts",
+      "/io/bufio.ts",
+      "/fmt/colors.ts"
+    ]
+  }
+}

--- a/modules-lock.json
+++ b/modules-lock.json
@@ -1,0 +1,1 @@
+{"https://deno.land/std":{"version":"@v0.18.0","modules":["/testing/mod.ts","/testing/asserts.ts","/io/bufio.ts","/fmt/colors.ts"]}}

--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,11 @@
 {
   "https://deno.land/std": {
-    "version": "@v0.17.0",
-    "modules": ["/testing/mod.ts", "/testing/asserts.ts", "/io/bufio.ts"]
+    "version": "@v0.18.0",
+    "modules": [
+      "/testing/mod.ts",
+      "/testing/asserts.ts",
+      "/io/bufio.ts",
+      "/fmt/colors.ts"
+    ]
   }
 }

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -14,7 +14,7 @@ export function createRedisPipeline(
   reader: BufReader,
   opts?: { tx: true }
 ): RedisPipeline {
-  let queue = [];
+  let queue: string[] = [];
   const executor = {
     enqueue(command: string, ...args) {
       const msg = createRequest(command, ...args);
@@ -29,7 +29,7 @@ export function createRedisPipeline(
       const msg = queue.join("");
       await writer.write(encoder.encode(msg));
       await writer.flush();
-      const ret = [];
+      const ret: RedisRawReply[] = [];
       for (let i = 0; i < queue.length; i++) {
         try {
           const rep = await readReply(reader);

--- a/pipeline_test.ts
+++ b/pipeline_test.ts
@@ -2,7 +2,11 @@ import { test } from "./vendor/https/deno.land/std/testing/mod.ts";
 import { assertEquals } from "./vendor/https/deno.land/std/testing/asserts.ts";
 import { connect } from "./redis.ts";
 
-const addr = "127.0.0.1:6379";
+const addr = {
+  hostname: "127.0.0.1",
+  port: 6379
+};
+
 test(async function testPipeline() {
   const redis = await connect(addr);
   const pl = redis.pipeline();

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -1,5 +1,5 @@
 import { BufReader, BufWriter } from "./vendor/https/deno.land/std/io/bufio.ts";
-import { createRequest, readArrayReply, sendCommand } from "./io.ts";
+import { readArrayReply, sendCommand } from "./io.ts";
 
 export type RedisSubscription = {
   readonly isClosed: boolean;

--- a/pubsub_test.ts
+++ b/pubsub_test.ts
@@ -3,7 +3,10 @@ import { assertEquals } from "./vendor/https/deno.land/std/testing/asserts.ts";
 import { connect } from "./redis.ts";
 import { RedisPubSubMessage } from "./pubsub.ts";
 
-const addr = "127.0.0.1:6379";
+const addr = {
+  hostname: "127.0.0.1",
+  port: 6379
+};
 
 async function wait(duration) {
   return new Promise(resolve => {

--- a/redis_test.ts
+++ b/redis_test.ts
@@ -1,8 +1,14 @@
 import { connect } from "./redis.ts";
-import { test } from "./vendor/https/deno.land/std/testing/mod.ts";
-import { assertEquals } from "./vendor/https/deno.land/std/testing/asserts.ts";
+import { runIfMain, test } from "./vendor/https/deno.land/std/testing/mod.ts";
+import {
+  assertEquals,
+  assertThrowsAsync
+} from "./vendor/https/deno.land/std/testing/asserts.ts";
 // can be substituted with env variable
-const addr = "127.0.0.1:6379";
+const addr = {
+  hostname: "127.0.0.1",
+  port: 6379
+};
 
 test(async function beforeAll() {
   const redis = await connect(addr);
@@ -101,3 +107,17 @@ test(async function testDecrby() {
   assertEquals(await redis.get("decryby"), "-101");
   redis.close();
 });
+
+[Infinity, NaN, "", "port"].forEach(v => {
+  test(`invalid port: ${v}`, () => {
+    assertThrowsAsync(
+      async () => {
+        await connect({ hostname: "127.0.0.1", port: v });
+      },
+      Error,
+      "invalid"
+    );
+  });
+});
+
+runIfMain(import.meta);

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,0 @@
-import "./redis_test.ts";
-import "./pubsub_test.ts";
-import "./pipeline_test.ts";
-import { runIfMain } from "./vendor/https/deno.land/std/testing/mod.ts";
-runIfMain(import.meta);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "noResolve": true,
+    "baseUrl": "/Users/keroxp/Library/Caches",
+    "strictNullChecks": true,
+    "paths": {
+      "deno": ["./deno.d.ts"],
+      "https://*": ["./deno/deps/https/*"],
+      "http://*": ["./deno/deps/http/*"]
+    }
+  }
+}

--- a/vendor/https/deno.land/std/fmt/colors.ts
+++ b/vendor/https/deno.land/std/fmt/colors.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@v0.18.0/fmt/colors.ts";

--- a/vendor/https/deno.land/std/io/bufio.ts
+++ b/vendor/https/deno.land/std/io/bufio.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.17.0/io/bufio.ts";
+export * from "https://deno.land/std@v0.18.0/io/bufio.ts";

--- a/vendor/https/deno.land/std/testing/asserts.ts
+++ b/vendor/https/deno.land/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.17.0/testing/asserts.ts";
+export * from "https://deno.land/std@v0.18.0/testing/asserts.ts";

--- a/vendor/https/deno.land/std/testing/mod.ts
+++ b/vendor/https/deno.land/std/testing/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.17.0/testing/mod.ts";
+export * from "https://deno.land/std@v0.18.0/testing/mod.ts";


### PR DESCRIPTION
- bump: deno@v0.19.0, deno_std@v0.18.0
- feat: TLS conn for redis server (via reverse-proxy)
- deprecated: `connect(addr)` will be removed in @v0.5.0 (about a month after)
  - this is because deno's breaking change about `dial` in @v0.19.0

