### PR TITLE
fix: improve signature of spop

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -232,7 +232,8 @@ export type Redis = {
   sismember(key: string, member: string): Promise<number>;
   smembers(key: string): Promise<string[]>;
   smove(source: string, destination: string, member: string): Promise<number>;
-  spop(key: string, count?: number): Promise<string>;
+  spop(key: string): Promise<string>;
+  spop(key: string, count: number): Promise<string[]>;
   srandmember(key: string, count?: number): Promise<string>;
   srem(key: string, ...members: string[]): Promise<number>;
   sunion(...keys: string[]): Promise<string[]>;
@@ -1266,7 +1267,9 @@ class RedisImpl implements Redis {
     }
   }
 
-  spop(...args) {
+  spop(key: string): Promise<string>;
+  spop(key: string, count: number): Promise<string[]>;
+  spop(...args): Promise<string | string[]> {
     return this.execStatusReply("SPOP", ...args);
   }
 

--- a/redis_test.ts
+++ b/redis_test.ts
@@ -6,7 +6,8 @@ import {
 } from "./vendor/https/deno.land/std/testing/mod.ts";
 import {
   assertEquals,
-  assertThrowsAsync
+  assertThrowsAsync,
+  assertArrayContains
 } from "./vendor/https/deno.land/std/testing/asserts.ts";
 // can be substituted with env variable
 const addr = {
@@ -25,7 +26,9 @@ test(async function beforeAll() {
     "get",
     "getset",
     "del1",
-    "del2"
+    "del2",
+    "spop",
+    "spopWithCount"
   );
 });
 
@@ -95,6 +98,18 @@ test(async function testDecrby() {
   const rep = await redis.decrby("decryby", 101);
   assertEquals(rep, -101);
   assertEquals(await redis.get("decryby"), "-101");
+});
+
+test(async function testSpop() {
+  await redis.sadd("spop", "a");
+  const v = await redis.spop("spop");
+  assertEquals(v, "a");
+});
+
+test(async function testSpopWithCount() {
+  await redis.sadd("spopWithCount", "a", "b");
+  const v = await redis.spop("spopWithCount", 2);
+  assertArrayContains(v, ["a", "b"]);
 });
 
 test(async function testConcurrent() {


### PR DESCRIPTION
## Summary

`Redis.spop()` returns an array when the `count` argument is passed in.
So I modified the signature of it.

## Example

```typescript
const redis = await connect({ hostname: 'localhost', port: 6379 });
const key = 'myset';
await redis.sadd(key, 'a', 'b', 'c');
console.info(await redis.spop(key)); // -> c
```
 
```typescript
const redis = await connect({ hostname: 'localhost', port: 6379 });
const key = 'myset';
await redis.sadd(key, 'a', 'b', 'c');
console.info(await redis.spop(key, 2)); // -> [ "a", "b" ]
```
