### PR TITLE
fix: zrange with 'withScore' option

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -1449,7 +1449,7 @@ class RedisImpl implements Redis {
   private pushZrangeOpts(args, opts?) {
     if (opts) {
       if (opts.withScore) {
-        args.push("WITHSCORE");
+        args.push("WITHSCORES");
       }
       if (opts.offset !== void 0 && opts.count !== void 0) {
         args.push("LIMIT", opts.offset, opts.count);

--- a/redis_test.ts
+++ b/redis_test.ts
@@ -28,7 +28,15 @@ test(async function beforeAll() {
     "del1",
     "del2",
     "spop",
-    "spopWithCount"
+    "spopWithCount",
+    "zrange",
+    "zrangeWithScores",
+    "zrevrange",
+    "zrevrangeWithScores",
+    "zrangebyscore",
+    "zrangebyscoreWithScores",
+    "zrevrangebyscore",
+    "zrevrangebyscoreWithScores"
   );
 });
 
@@ -110,6 +118,74 @@ test(async function testSpopWithCount() {
   await redis.sadd("spopWithCount", "a", "b");
   const v = await redis.spop("spopWithCount", 2);
   assertArrayContains(v, ["a", "b"]);
+});
+
+test(async function testZrange() {
+  redis.zadd("zrange", 1, "one");
+  redis.zadd("zrange", 2, "two");
+  redis.zadd("zrange", 3, "three");
+  const v = await redis.zrange("zrange", 0, 1);
+  assertEquals(v, ["one", "two"]);
+});
+
+test(async function testZrangeWithScores() {
+  redis.zadd("zrangeWithScores", 1, "one");
+  redis.zadd("zrangeWithScores", 2, "two");
+  redis.zadd("zrangeWithScores", 3, "three");
+  const v = await redis.zrange("zrangeWithScores", 0, 1, { withScore: true });
+  assertEquals(v, ["one", "1", "two", "2"]);
+});
+
+test(async function testZrevrange() {
+  redis.zadd("zrevrange", 1, "one");
+  redis.zadd("zrevrange", 2, "two");
+  redis.zadd("zrevrange", 3, "three");
+  const v = await redis.zrevrange("zrevrange", 0, 1)
+  assertEquals(v, ["three", "two"]);
+});
+
+test(async function testZrevrangeWithScores() {
+  redis.zadd("zrevrangeWithScores", 1, "one");
+  redis.zadd("zrevrangeWithScores", 2, "two");
+  redis.zadd("zrevrangeWithScores", 3, "three");
+  const v = await redis.zrevrange("zrevrangeWithScores", 0, 1, { withScore: true });
+  assertEquals(v, ["three", "3", "two", "2"]);
+});
+
+test(async function testZrangebyscore() {
+  redis.zadd("zrangebyscore", 2, "m1");
+  redis.zadd("zrangebyscore", 5, "m2");
+  redis.zadd("zrangebyscore", 8, "m3");
+  redis.zadd("zrangebyscore", 10, "m4"); 
+  const v = await redis.zrangebyscore("zrangebyscore", 3, 9);
+  assertEquals(v, ["m2", "m3"]);
+});
+
+test(async function testZrangebyscoreWithScores() {
+  redis.zadd("zrangebyscoreWithScores", 2, "m1");
+  redis.zadd("zrangebyscoreWithScores", 5, "m2");
+  redis.zadd("zrangebyscoreWithScores", 8, "m3");
+  redis.zadd("zrangebyscoreWithScores", 10, "m4"); 
+  const v = await redis.zrangebyscore("zrangebyscoreWithScores", 3, 9, { withScore: true });
+  assertEquals(v, ["m2", "5", "m3", "8"]);
+});
+
+test(async function testZrevrangebyscore() {
+  redis.zadd("zrevrangebyscore", 2, "m1");
+  redis.zadd("zrevrangebyscore", 5, "m2");
+  redis.zadd("zrevrangebyscore", 8, "m3");
+  redis.zadd("zrevrangebyscore", 10, "m4"); 
+  const v = await redis.zrevrangebyscore("zrevrangebyscore", 9, 4);
+  assertEquals(v, ["m3", "m2"]);
+});
+
+test(async function testZrevrangebyscore() {
+  redis.zadd("zrevrangebyscoreWithScores", 2, "m1");
+  redis.zadd("zrevrangebyscoreWithScores", 5, "m2");
+  redis.zadd("zrevrangebyscoreWithScores", 8, "m3");
+  redis.zadd("zrevrangebyscoreWithScores", 10, "m4"); 
+  const v = await redis.zrevrangebyscore("zrevrangebyscoreWithScores", 9, 4, { withScore: true });
+  assertEquals(v, ["m3", "8", "m2", "5"]);
 });
 
 test(async function testConcurrent() {


### PR DESCRIPTION
## Summary

`Redis.zrange()` does not work when used with `withScore` option.

This PR fixes this problem.

```typescript
const redis = await connect({ hostname: 'localhost', port: 6379 });
await redis.zadd('myzset', 1, 'one');
await redis.zrange('myzset', 0, -1, { withScore: true });
```

```
error: Uncaught Error: -ERR syntax error

► io.ts:149:11

149     throw new ErrorReplyError(line);
              ^

    at ErrorReplyError (errors.ts:5:7)
    at tryParseErrorReply (io.ts:149:11)
    at readReply (io.ts:65:7)
```