### PR TITLE
added: string_test.ts

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -82,7 +82,7 @@ export type RedisCommands<TRaw, TStatus, TInteger, TBulk, TArray, TBulkNil> = {
   append(key: string, value: string): Promise<TInteger>;
   bitcount(key: string): Promise<TInteger>;
   bitcount(key: string, start: number, end: number): Promise<TInteger>;
-  bitfield(): Promise<TArray>;
+  bitfield(key: string): Promise<TArray>;
   bitop(
     operation: "AND" | "OR" | "XOR" | "NOT",
     destkey: string,
@@ -98,7 +98,7 @@ export type RedisCommands<TRaw, TStatus, TInteger, TBulk, TArray, TBulkNil> = {
   decrby(key: string, decrement: number): Promise<TInteger>;
   incr(key: string): Promise<TInteger>;
   incrby(key: string, increment: number): Promise<TInteger>;
-  incrbyfloat(key: string, increment: number): Promise<TStatus>;
+  incrbyfloat(key: string, increment: number): Promise<TBulk>;
   mget(...keys: string[]): Promise<TArray>;
   mset(key: string, value: string): Promise<TStatus>;
   mset(...key_values: string[]): Promise<TStatus>;
@@ -129,7 +129,7 @@ export type RedisCommands<TRaw, TStatus, TInteger, TBulk, TArray, TBulkNil> = {
   strlen(key: string): Promise<TInteger>;
   get(key: string): Promise<TBulk>;
   getbit(key: string, offset: number): Promise<TInteger>;
-  getrange(key: string, start: number, end: number): Promise<TStatus>;
+  getrange(key: string, start: number, end: number): Promise<TBulk>;
   getset(key: string, value: string): Promise<TBulk>;
   // Geo
   geoadd(
@@ -520,8 +520,8 @@ class RedisImpl<TRaw, TStatus, TInteger, TBulk, TArray, TBulkNil>
     } else return this.execIntegerReply("BITCOUNT", key);
   }
 
-  bitfield() {
-    return this.execArrayReply("BITFIELD");
+  bitfield(key: string) {
+    return this.execArrayReply("BITFIELD", key);
   }
 
   bitop(operation: string, destkey: string, ...keys: string[]) {
@@ -812,7 +812,7 @@ class RedisImpl<TRaw, TStatus, TInteger, TBulk, TArray, TBulkNil>
   }
 
   getrange(key: string, start: number, end: number) {
-    return this.execStatusReply("GETRANGE", key, start, end);
+    return this.execBulkReply("GETRANGE", key, start, end);
   }
 
   getset(key: string, value: string) {
@@ -884,7 +884,7 @@ class RedisImpl<TRaw, TStatus, TInteger, TBulk, TArray, TBulkNil>
   }
 
   incrbyfloat(key: string, increment: number) {
-    return this.execStatusReply("INCRBYFLOAT", key, increment);
+    return this.execBulkReply("INCRBYFLOAT", key, increment);
   }
 
   info(section?: string) {

--- a/redis_test.ts
+++ b/redis_test.ts
@@ -23,33 +23,6 @@ test(async function testExists() {
   assertEquals(exists, 1);
 });
 
-test(async function testGetWhenNil() {
-  const hoge = await redis.get("none");
-  assertEquals(hoge, undefined);
-});
-
-test(async function testSet() {
-  const s = await redis.set("get", "fuga你好こんにちは");
-  assertEquals(s, "OK");
-  const fuga = await redis.get("get");
-  assertEquals(fuga, "fuga你好こんにちは");
-});
-
-test(async function testGetSet() {
-  await redis.set("getset", "val");
-  const v = await redis.getset("getset", "lav");
-  assertEquals(v, "val");
-  assertEquals(await redis.get("getset"), "lav");
-});
-
-test(async function testMget() {
-  await redis.set("mget1", "val1");
-  await redis.set("mget2", "val2");
-  await redis.set("mget3", "val3");
-  const v = await redis.mget("mget1", "mget2", "mget3");
-  assertEquals(v, ["val1", "val2", "val3"]);
-});
-
 test(async function testDel() {
   let s = await redis.set("del1", "fuga");
   assertEquals(s, "OK");
@@ -57,30 +30,6 @@ test(async function testDel() {
   assertEquals(s, "OK");
   const deleted = await redis.del("del1", "del2");
   assertEquals(deleted, 2);
-});
-
-test(async function testIncr() {
-  const rep = await redis.incr("incr");
-  assertEquals(rep, 1);
-  assertEquals(await redis.get("incr"), "1");
-});
-
-test(async function testIncrby() {
-  const rep = await redis.incrby("incrby", 101);
-  assertEquals(rep, 101);
-  assertEquals(await redis.get("incrby"), "101");
-});
-
-test(async function testDecr() {
-  const rep = await redis.decr("decr");
-  assertEquals(rep, -1);
-  assertEquals(await redis.get("decr"), "-1");
-});
-
-test(async function testDecrby() {
-  const rep = await redis.decrby("decryby", 101);
-  assertEquals(rep, -101);
-  assertEquals(await redis.get("decryby"), "-101");
 });
 
 test(async function testConcurrent() {

--- a/tests/string_test.ts
+++ b/tests/string_test.ts
@@ -1,0 +1,181 @@
+import { makeTest, sleep } from "./test_util.ts";
+import {
+  assertEquals,
+  assert
+} from "../vendor/https/deno.land/std/testing/asserts.ts";
+const { test, client } = await makeTest("string");
+
+test("append", async () => {
+  await client.set("key", "foo");
+  const rep = await client.append("key", "bar");
+  assertEquals(rep, 6);
+  const v = await client.get("key");
+  assertEquals(v, "foobar");
+});
+
+test("bitcount", async () => {
+  await client.set("key", "foo"); // 01100110 01101111 01101111
+  const v = await client.bitcount("key");
+  assertEquals(v, 16);
+});
+
+test("bitfieldWithoutOperations", async () => {
+  await client.set("key", "test");
+  const v = await client.bitfield("key");
+  assertEquals(v, []);
+});
+
+test("bitop", async () => {
+  await client.set("key1", "foo"); // 01100110 01101111 01101111
+  await client.set("key2", "bar"); // 01100010 01100001 01110010
+  await client.bitop("AND", "dest", "key1", "key2");
+  const v = await client.get("dest");
+  assertEquals(v, "bab"); // 01100010 01100001 01100000
+});
+
+test("bitpos", async () => {
+  await client.set("key", "2"); // 00110010
+  assertEquals(await client.bitpos("key", 0), 0);
+  assertEquals(await client.bitpos("key", 1), 2);
+});
+
+test("decr", async () => {
+  const rep = await client.decr("key");
+  assertEquals(rep, -1);
+  assertEquals(await client.get("key"), "-1");
+});
+
+test("decby", async () => {
+  const rep = await client.decrby("key", 101);
+  assertEquals(rep, -101);
+  assertEquals(await client.get("key"), "-101");
+});
+
+test("getWhenNil", async () => {
+  const hoge = await client.get("none");
+  assertEquals(hoge, undefined);
+});
+
+test("getbit", async () => {
+  await client.set("key", "3"); // 00110011
+  assertEquals(await client.getbit("key", 0), 0);
+  assertEquals(await client.getbit("key", 2), 1);
+});
+
+test("getrange", async () => {
+  await client.set("key", "Hello world!");
+  const v = await client.getrange("key", 6, 10);
+  assertEquals(v, "world");
+});
+
+test("getset", async function testGetSet() {
+  await client.set("key", "val");
+  const v = await client.getset("key", "lav");
+  assertEquals(v, "val");
+  assertEquals(await client.get("key"), "lav");
+});
+
+test("incr", async () => {
+  const rep = await client.incr("key");
+  assertEquals(rep, 1);
+  assertEquals(await client.get("key"), "1");
+});
+
+test("incrby", async () => {
+  const rep = await client.incrby("key", 101);
+  assertEquals(rep, 101);
+  assertEquals(await client.get("key"), "101");
+});
+
+test("incrbyfloat", async () => {
+  await client.set("key", "2.1");
+  const v = await client.incrbyfloat("key", 0.5);
+  assertEquals(v, "2.6");
+  assertEquals(await client.get("key"), "2.6");
+});
+
+test("mget", async () => {
+  await client.set("key1", "val1");
+  await client.set("key2", "val2");
+  await client.set("key3", "val3");
+  const v = await client.mget("key1", "key2", "key3");
+  assertEquals(v, ["val1", "val2", "val3"]);
+});
+
+test("mset", async () => {
+  const rep = await client.mset("key1", "foo", "key2", "bar", "key3", "baz");
+  assertEquals(rep, "OK");
+  assertEquals(await client.get("key1"), "foo");
+  assertEquals(await client.get("key2"), "bar");
+  assertEquals(await client.get("key3"), "baz");
+});
+
+test("msetnx", async () => {
+  const rep1 = await client.msetnx("key1", "foo", "key2", "bar");
+  assertEquals(rep1, 1); // All the keys were set.
+  const rep2 = await client.msetnx("key2", "baz", "key3", "qux");
+  assertEquals(rep2, 0); // No key was set.
+  assertEquals(await client.get("key1"), "foo");
+  assertEquals(await client.get("key2"), "bar");
+  assertEquals(await client.get("key3"), undefined);
+});
+
+// This test is a bit slow.
+test("psetex #slow", async () => {
+  const rep = await client.psetex("key1", 1000, "test");
+  assertEquals(rep, "OK");
+  assertEquals(await client.get("key1"), "test");
+  await sleep(1000);
+  assert(!await client.exists("key1"));
+});
+
+test("set", async () => {
+  const s = await client.set("key", "fuga你好こんにちは");
+  assertEquals(s, "OK");
+  const fuga = await client.get("key");
+  assertEquals(fuga, "fuga你好こんにちは");
+});
+
+test("setbit", async () => {
+  await client.set("key", "2"); // 00110010
+  assertEquals(
+    0,
+    await client.setbit("key", 1, "1") // 01110010
+  );
+  assertEquals(
+    1,
+    await client.setbit("key", 3, "0") // 01100010 => b
+  );
+  const v = await client.get("key");
+  assertEquals(v, "b");
+});
+
+// This test is a bit slow.
+test("setex #slow", async () => {
+  const rep = await client.setex("key", 1, "test");
+  assertEquals(rep, "OK");
+  assertEquals(await client.get("key"), "test");
+  await sleep(1000);
+  assert(!await client.exists("key"));
+});
+
+test("setnx", async () => {
+  assertEquals(await client.setnx("key", "foo"), 1);
+  assertEquals(await client.setnx("key", "bar"), 0);
+  const v = await client.get("key");
+  assertEquals(v, "foo");
+});
+
+test("setrange", async () => {
+  await client.set("key", "Hello, Deno!");
+  const rep = await client.setrange("key", 7, "Redis!");
+  assertEquals(rep, 13);
+  const v = await client.get("key");
+  assertEquals(v, "Hello, Redis!");
+});
+
+test("strlen", async () => {
+  await client.set("key", "foobar");
+  const v = await client.strlen("key");
+  assertEquals(v, 6);
+});

--- a/tests/string_test.ts
+++ b/tests/string_test.ts
@@ -1,4 +1,4 @@
-import { makeTest, sleep } from "./test_util.ts";
+import { makeTest } from "./test_util.ts";
 import {
   assertEquals,
   assert
@@ -120,13 +120,10 @@ test("msetnx", async () => {
   assertEquals(await client.get("key3"), undefined);
 });
 
-// This test is a bit slow.
-test("psetex #slow", async () => {
+test("psetex", async () => {
   const rep = await client.psetex("key1", 1000, "test");
   assertEquals(rep, "OK");
   assertEquals(await client.get("key1"), "test");
-  await sleep(1000);
-  assert(!await client.exists("key1"));
 });
 
 test("set", async () => {
@@ -150,13 +147,10 @@ test("setbit", async () => {
   assertEquals(v, "b");
 });
 
-// This test is a bit slow.
-test("setex #slow", async () => {
+test("setex", async () => {
   const rep = await client.setex("key", 1, "test");
   assertEquals(rep, "OK");
   assertEquals(await client.get("key"), "test");
-  await sleep(1000);
-  assert(!await client.exists("key"));
 });
 
 test("setnx", async () => {

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -36,3 +36,7 @@ export async function makeTest(
   };
   return { test, client };
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise<any>(resolve => setTimeout(resolve, ms));
+}

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -36,7 +36,3 @@ export async function makeTest(
   };
   return { test, client };
 }
-
-export function sleep(ms: number): Promise<void> {
-  return new Promise<any>(resolve => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
- Added tests for string commands.
- Fixed `getrange` because to avoid the following warning:
  - `wrong type definition for status: GETRANGE bulk world`
- Fixed `incrbyfloat` because to avoid the following warning:
  - `wrong type definition for status: INCRBYFLOAT bulk 2.6`
- Noticed that `bitfield` is not completely implemented yet.
  - I'll open an issue about this.
