### PR TITLE
feat: password authentication

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -1462,6 +1462,7 @@ export type RedisConnectOptions = {
   port?: number | string;
   tls?: boolean;
   db?: number;
+  password?: string;
 };
 
 function prasePortLike(port: string | number | undefined): number {
@@ -1488,6 +1489,7 @@ export async function connect({
   port,
   tls,
   db,
+  password,
 }: RedisConnectOptions): Promise<Redis> {
   const dialOpts: Deno.ConnectOptions = {
     hostname,
@@ -1504,6 +1506,14 @@ export async function connect({
   const bufw = new BufWriter(conn);
   const exec = muxExecutor(bufr, bufw);
   const client = await create(conn, conn, conn, exec);
+  if (password) {
+    try {
+      await client.auth(password);
+    } catch (err) {
+      client.close();
+      return Promise.reject(err);
+    }
+  }
   if (db) {
     await client.select(db);
   }

--- a/redis.ts
+++ b/redis.ts
@@ -1511,7 +1511,7 @@ export async function connect({
       await client.auth(password);
     } catch (err) {
       client.close();
-      return Promise.reject(err);
+      throw err;
     }
   }
   if (db) {

--- a/redis.ts
+++ b/redis.ts
@@ -1506,7 +1506,7 @@ export async function connect({
   const bufw = new BufWriter(conn);
   const exec = muxExecutor(bufr, bufw);
   const client = await create(conn, conn, conn, exec);
-  if (password) {
+  if (password != null) {
     try {
       await client.auth(password);
     } catch (err) {

--- a/tests/general_test.ts
+++ b/tests/general_test.ts
@@ -4,6 +4,8 @@ import {
   assertThrowsAsync,
 } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import { makeTest } from "./test_util.ts";
+import { ErrorReplyError } from "../errors.ts";
+import { Redis } from "../redis.ts";
 
 const { test, client: redis, opts } = await makeTest("general");
 test("conccurent", async function testConcurrent() {
@@ -33,6 +35,15 @@ test("db0", async function testDb0Option() {
   assertEquals(exists2, 1);
   client1.close();
   client2.close();
+});
+
+test("connect with wrong password", async function testConnectWithPassword() {
+  await assertThrowsAsync(async () => {
+    await connect({
+      ...opts,
+      password: "wrong_password",
+    });
+  }, ErrorReplyError);
 });
 
 test("exists", async function testDb1Option() {

--- a/tests/general_test.ts
+++ b/tests/general_test.ts
@@ -37,11 +37,21 @@ test("db0", async function testDb0Option() {
   client2.close();
 });
 
-test("connect with wrong password", async function testConnectWithPassword() {
+test("connect with wrong password", async function testConnectWithWrongPassword() {
   await assertThrowsAsync(async () => {
     await connect({
       ...opts,
       password: "wrong_password",
+    });
+  }, ErrorReplyError);
+});
+
+test("connect with empty password", async function testConnectWithEmptyPassword() {
+  // In Redis, authentication with an empty password will always fail.
+  await assertThrowsAsync(async () => {
+    await connect({
+      ...opts,
+      password: "",
     });
   }, ErrorReplyError);
 });


### PR DESCRIPTION
This PR resolves #81.
Please review @keroxp 🙏, cc @devalexqt.

- Added the `password` property to `RedisConnectOptions`.
- `AUTH` command is now executed automatically when password is specified.